### PR TITLE
Fix sign up form not showing error message

### DIFF
--- a/src/pages/sign-up/sign-up.html
+++ b/src/pages/sign-up/sign-up.html
@@ -12,7 +12,7 @@
 
 <!--</ion-header>-->
 
-<form [formGroup]="form" (ngSubmit)="signup()" style="width: 100%; height: 100%">
+<form [formGroup]="form" style="width: 100%; height: 100%">
     <ion-content>
         <ion-grid>
             <ion-row>

--- a/src/pages/sign-up/sign-up.ts
+++ b/src/pages/sign-up/sign-up.ts
@@ -85,9 +85,6 @@ export class SignUpPage implements OnInit {
       loading.dismiss().then(() => {/* meh */
       });
       const apiResponse = formatAPIError(error) as ApiResponse;
-      if (!apiResponse.hasOwnProperty('status')) {
-        return;
-      }
       let subTitle = !!apiResponse.non_field_errors ? apiResponse.non_field_errors[0] :
         'There was a problem contacting the server, try again later';
       switch (error.status) {


### PR DESCRIPTION
sign-up.html:
`signup()` is being called on the submit button. Removed the call on the form as it this resulted in two requests being sent.

sign-up.ts:
`ApiResponse` will never have a `status` property, hence the message would never display.
Opted to remove the conditional block (rather than modifying) as it does not appear to accomplish anything.

Ref: https://youtrack.gaiaresources.com.au/youtrack/issue/SLUG-25